### PR TITLE
Update validation visitor

### DIFF
--- a/validation-processor/src/main/java/io/micronaut/validation/visitor/ValidationVisitor.java
+++ b/validation-processor/src/main/java/io/micronaut/validation/visitor/ValidationVisitor.java
@@ -94,6 +94,7 @@ public class ValidationVisitor implements TypeElementVisitor<Object, Object> {
 
         if (
             requiresValidation(element.getReturnType(), requireOnConstraint) ||
+            (element.getReturnType().isPrimitive() && primitiveReturnTypeRequiresValidation(element, true)) ||
             parametersRequireValidation(element, requireOnConstraint)
         ) {
             if (isPrivate) {
@@ -118,6 +119,11 @@ public class ValidationVisitor implements TypeElementVisitor<Object, Object> {
     private boolean parametersRequireValidation(MethodElement element, boolean requireOnConstraint) {
         return Arrays.stream(element.getParameters())
             .anyMatch(param -> requiresValidation(param, requireOnConstraint));
+    }
+
+    private boolean primitiveReturnTypeRequiresValidation(MethodElement e, boolean requireOnConstraint) {
+        return e.hasStereotype(ANN_VALID) ||
+            (requireOnConstraint && e.hasStereotype(ANN_CONSTRAINT));
     }
 
     private boolean requiresValidation(TypedElement e, boolean requireOnConstraint) {

--- a/validation-processor/src/main/java/io/micronaut/validation/visitor/ValidationVisitor.java
+++ b/validation-processor/src/main/java/io/micronaut/validation/visitor/ValidationVisitor.java
@@ -20,6 +20,7 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.ConstructorElement;
 import io.micronaut.inject.ast.FieldElement;
+import io.micronaut.inject.ast.GenericPlaceholderElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.TypedElement;
 import io.micronaut.inject.processing.ProcessingException;
@@ -133,6 +134,11 @@ public class ValidationVisitor implements TypeElementVisitor<Object, Object> {
     }
 
     private boolean typeArgumentsRequireValidation(TypedElement e, boolean requireOnConstraint) {
+        if (e instanceof GenericPlaceholderElement) {
+            // To avoid infinite loops in case of circular generic dependency
+            // For example, in case of A<? extends B>, B<? extends A>
+            return false;
+        }
         return e.getGenericType().getTypeArguments().values().stream()
             .anyMatch(classElement -> requiresValidation(classElement, requireOnConstraint));
     }


### PR DESCRIPTION
Update:
* to avoid infinite loop in generic parameters
* work correctly for primitive return types (annotations are present on the method, not the return type)