### PR TITLE
doc: validation-processor is required

### DIFF
--- a/src/main/docs/guide/compileTimeValidation.adoc
+++ b/src/main/docs/guide/compileTimeValidation.adoc
@@ -1,9 +1,9 @@
+Micronaut Validation validates annotation elements at compile time with `micronaut-validation-processor` in the annotation processor classpath:
 
-You can use Micronaut's validator to validate annotation elements at compile time by including `micronaut-validation` in the annotation processor classpath:
+dependency:micronaut-validation-processor[groupId="io.micronaut.validation",scope="annotationProcessor"]
 
-dependency::io.micronaut.validation:micronaut-validation[scope="annotationProcessor"]
-
-Then Micronaut will at compile time validate annotation values that are themselves annotated with `javax.validation`. For example consider the following annotation:
+Micronaut Validation will, at compile time, validate annotation values that are themselves annotated with `javax.validation`.
+For example consider the following annotation:
 
 .Annotation Validation
 snippet::io.micronaut.docs.validation.custom.TimeOff[tags="imports,class", indent="0"]


### PR DESCRIPTION
Fix dependency and change copy to reflect that validation-processor is not optional.

![CleanShot 2023-03-03 at 12 08 35@2x](https://user-images.githubusercontent.com/864788/222705773-ce711ae4-f64f-4bc4-a412-269eb73b7b94.png)