### PR TITLE
Fix annotation processing patterns

### DIFF
--- a/validation-processor/src/main/java/io/micronaut/validation/visitor/IntrospectedValidationIndexesVisitor.java
+++ b/validation-processor/src/main/java/io/micronaut/validation/visitor/IntrospectedValidationIndexesVisitor.java
@@ -56,6 +56,11 @@ public class IntrospectedValidationIndexesVisitor implements TypeElementVisitor<
         return IntrospectedTypeElementVisitor.POSITION + 10; // Should just before the introspected visitor
     }
 
+    @Override
+    public Set<String> getSupportedAnnotationNames() {
+        return Set.of("jakarta.validation.*");
+    }
+
     @NonNull
     @Override
     public VisitorKind getVisitorKind() {

--- a/validation-processor/src/main/java/io/micronaut/validation/visitor/ValidationVisitor.java
+++ b/validation-processor/src/main/java/io/micronaut/validation/visitor/ValidationVisitor.java
@@ -53,7 +53,7 @@ public class ValidationVisitor implements TypeElementVisitor<Object, Object> {
 
     @Override
     public Set<String> getSupportedAnnotationNames() {
-        return Set.of(ANN_CONSTRAINT, ANN_VALID);
+        return Set.of("jakarta.validation.*");
     }
 
     @Override


### PR DESCRIPTION
The annotation processing needs to catch all jakarta validation annotations for it work incrementally because Java's APT is not aware of stereotypes. Also `IntrospectedValidationIndexesVisitor` didn't specify any limitation so would break incremental compilation.