### PR TITLE
#54 Fix guide links

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,6 @@ bomProperty=micronautValidationVersion
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx1g
 predictiveTestSelection=false
+
+coreDocsUrl=https://docs.micronaut.io/latest/api/io/micronaut/
+guideUrl=https://docs.micronaut.io/latest/guide/

--- a/src/main/docs/guide/additionalConstraints.adoc
+++ b/src/main/docs/guide/additionalConstraints.adoc
@@ -1,14 +1,13 @@
-
 To define additional constraints, create a new annotation, for example:
 
 .Example Constraint Annotation
 snippet::io.micronaut.docs.validation.custom.DurationPattern[tags="imports,class", indent="0"]
 
 <1> The annotation should be annotated with `jakarta.validation.Constraint`
-<2> A `message` template can be provided in a hard-coded manner as above. If none is specified, Micronaut tries to find a message using `ClassName.message` using the api:context.MessageSource[] interface (optional)
+<2> A `message` template can be provided in a hard-coded manner as above. If none is specified, Micronaut tries to find a message using `ClassName.message` using the {coreDocsUrl}context/MessageSource[MessageSource] interface (optional)
 <3> To support repeated annotations you can define an inner annotation (optional)
 
-TIP: You can add messages and message bundles using the api:context.MessageSource[] and api:context.i18n.ResourceBundleMessageSource[] classes. See <<bundle, Resource Bundles>> documentation.
+TIP: You can add messages and message bundles using the {coreDocsUrl}context/MessageSource[MessageSource] and {coreDocsUrl}context/i18n/ResourceBundleMessageSource[ResourceBundleMessageSource] classes. See {guideUrl}#bundle[Resource Bundles] documentation.
 
 Once you have defined the annotation, implement a api:validation.validator.constraints.ConstraintValidator[] that validates the annotation. You can either create a bean class that implements the interface directly or define a factory that returns one or more validators.
 

--- a/src/main/docs/guide/configurationValidation.adoc
+++ b/src/main/docs/guide/configurationValidation.adoc
@@ -1,4 +1,3 @@
+You can also validate the properties of classes that are annotated with {coreDocsUrl}context/annotation/ConfigurationProperties[@ConfigurationProperties] to ensure configuration is correct.
 
-You can also validate the properties of classes that are annotated with ann:context.annotation.ConfigurationProperties[] to ensure configuration is correct.
-
-NOTE: It is recommended that you annotate ann:context.annotation.ConfigurationProperties[] that features validation with ann:context.annotation.Context[] to ensure that the validation occurs at startup.
+NOTE: It is recommended that you annotate {coreDocsUrl}context/annotation/ConfigurationProperties[@ConfigurationProperties] that features validation with {coreDocsUrl}context/annotation/Context[@Context] to ensure that the validation occurs at startup.

--- a/src/main/docs/guide/dataClassesValidation.adoc
+++ b/src/main/docs/guide/dataClassesValidation.adoc
@@ -1,10 +1,9 @@
-
-To validate data classes, e.g. POJOs (typically used in JSON interchange), the class must be annotated with ann:core.annotation.Introspected[] (see link:https://docs.micronaut.io/latest/guide/#introspection[Micronaut Guide Introspection section]) or, if the class is external, be imported by the `@Introspected` annotation.
+To validate data classes, e.g. POJOs (typically used in JSON interchange), the class must be annotated with {coreDocsUrl}core/annotation/Introspected[@Introspected] (see link:https://docs.micronaut.io/latest/guide/#introspection[Micronaut Guide Introspection section]) or, if the class is external, be imported by the `@Introspected` annotation.
 
 .POJO Validation Example
 snippet::io.micronaut.docs.validation.Person[tags="class"]
 
-TIP: The ann:core.annotation.Introspected[] annotation can be used as a meta-annotation; common annotations like `@javax.persistence.Entity` are treated as `@Introspected`
+TIP: The {coreDocsUrl}core/annotation/Introspected[@Introspected] annotation can be used as a meta-annotation; common annotations like `@javax.persistence.Entity` are treated as `@Introspected`
 
 The above example defines a `Person` class that has two properties (`name` and `age`) that have constraints applied. Note that in Java the annotations can be on the field or the getter, and with Kotlin data classes, the annotation should target the field.
 


### PR DESCRIPTION
Fix guide links based on the issue #54.

Does not fix links to the `Validator`, `ConstraintValidator` and `@Validated` as those classes are in this repository and should reference its docs.