### PR TITLE
build: Micronaut Framework to 4.0.0-M1

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.validation-test-suite.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.validation-test-suite.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'io.micronaut.build.internal.validation-base'
+    id 'java'
+    id 'io.micronaut.application'
+}
+micronaut {
+    // Do not build examples against M1 since the platform is not released
+    version = "4.0.0-SNAPSHOT"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-micronaut = "4.0.0-SNAPSHOT"
+micronaut = "4.0.0-M1"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.0.0-SNAPSHOT"
 micronaut-reactor = "3.0.0-SNAPSHOT"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 micronaut = "4.0.0-M1"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.0.0-SNAPSHOT"
-micronaut-rxjava2 = "2.0.0-SNAPSHOT"
 micronaut-reactor = "3.0.0-M1"
+micronaut-rxjava2 = "2.0.0-M1"
 micronaut-kotlin = "4.0.0-SNAPSHOT"
 
 groovy = "4.0.9"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 micronaut = "4.0.0-M1"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.0.0-SNAPSHOT"
-micronaut-reactor = "3.0.0-SNAPSHOT"
 micronaut-rxjava2 = "2.0.0-SNAPSHOT"
+micronaut-reactor = "3.0.0-M1"
 micronaut-kotlin = "4.0.0-SNAPSHOT"
 
 groovy = "4.0.9"

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.validation-base'
-    id 'java'
-    id 'io.micronaut.application'
+    id 'io.micronaut.build.internal.validation-test-suite'
 }
 
 dependencies {

--- a/test-suite-kotlin/build.gradle
+++ b/test-suite-kotlin/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.validation-base'
-    id 'java'
-    id 'io.micronaut.application'
+    id 'io.micronaut.build.internal.validation-test-suite'
     id 'org.jetbrains.kotlin.jvm'
     id 'com.google.devtools.ksp'
 }

--- a/test-suite/build.gradle
+++ b/test-suite/build.gradle
@@ -1,7 +1,5 @@
 plugins {
-    id 'io.micronaut.build.internal.validation-base'
-    id 'java'
-    id 'io.micronaut.application'
+    id 'io.micronaut.build.internal.validation-test-suite'
 }
 
 dependencies {
@@ -28,3 +26,4 @@ dependencies {
     testImplementation libs.junit.jupiter.engine
     testRuntimeOnly libs.junit.jupiter.engine
 }
+


### PR DESCRIPTION
- Micronaut Framework to 4.0.0-M1
- Micronaut Reactor to 3.0.0-M1
- Micronaut RxJava2 to 2.0.0-M1
- use snapshot for test-suite modules