### PR TITLE
ci: set projectVersion to 1.0.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.0.0-SNAPSHOT
+projectVersion=1.0.0-SNAPSHOT
 projectGroup=io.micronaut.validation
 
 title=Micronaut Validation


### PR DESCRIPTION
This sets the project version to 1.0.0-SNAPSHOT since there was never a release of micronaut-validation