### PR TITLE
Downgrade core processor dependency scope

### DIFF
--- a/validation-processor/build.gradle
+++ b/validation-processor/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api mn.micronaut.core.processor
+    compileOnly mn.micronaut.core.processor
     implementation projects.validation
 
     testImplementation mn.micronaut.core.reactive


### PR DESCRIPTION
This PR changes the scope of the Micronaut Core annotation processor from `api` to `compileOnly`.

Now that Validation is separated from Core, exposing the Core processor as an API dependency is causing trouble in Maven projects. If the Core version defined in the project and the one exposed by Validation are different, both will end up in the annotation processor classpath. This is because Maven doesn't enforce dependency management rules in annotation processor classpaths, as explained in [MCOMPILER-391](https://issues.apache.org/jira/browse/MCOMPILER-391). 

Once https://github.com/apache/maven-compiler-plugin/pull/180 is merged and released, we may see a solution for this issue, but regardless of that, it is incorrect to expose a Core processor (which is already in the processor classpath for all Micronaut applications).