### PR TITLE
Throw errors from validated reactive methods immediately

### DIFF
--- a/validation/src/main/java/io/micronaut/validation/ValidatingInterceptor.java
+++ b/validation/src/main/java/io/micronaut/validation/ValidatingInterceptor.java
@@ -121,27 +121,23 @@ public class ValidatingInterceptor implements MethodInterceptor<Object, Object> 
             }
             if (micronautValidator instanceof ReactiveValidator) {
                 InterceptedMethod interceptedMethod = InterceptedMethod.of(context, conversionService);
-                try {
-                    return switch (interceptedMethod.resultType()) {
-                        case PUBLISHER -> interceptedMethod.handleResult(
-                            ((ReactiveValidator) micronautValidator).validatePublisher(
-                                context.getReturnType(),
-                                interceptedMethod.interceptResultAsPublisher(),
-                                getValidationGroups(context))
-                        );
-                        case COMPLETION_STAGE -> interceptedMethod.handleResult(
-                            ((ReactiveValidator) micronautValidator).validateCompletionStage(
-                                (CompletionStage<Object>) interceptedMethod.interceptResultAsCompletionStage(),
-                                (Argument<Object>) context.getReturnType().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT),
-                                getValidationGroups(context))
-                        );
-                        case SYNCHRONOUS ->
-                            validateReturnMicronautValidator(context, executableMethod);
-                        default -> interceptedMethod.unsupported();
-                    };
-                } catch (Exception e) {
-                    return interceptedMethod.handleException(e);
-                }
+                return switch (interceptedMethod.resultType()) {
+                    case PUBLISHER -> interceptedMethod.handleResult(
+                        ((ReactiveValidator) micronautValidator).validatePublisher(
+                            context.getReturnType(),
+                            interceptedMethod.interceptResultAsPublisher(),
+                            getValidationGroups(context))
+                    );
+                    case COMPLETION_STAGE -> interceptedMethod.handleResult(
+                        ((ReactiveValidator) micronautValidator).validateCompletionStage(
+                            (CompletionStage<Object>) interceptedMethod.interceptResultAsCompletionStage(),
+                            (Argument<Object>) context.getReturnType().getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT),
+                            getValidationGroups(context))
+                    );
+                    case SYNCHRONOUS ->
+                        validateReturnMicronautValidator(context, executableMethod);
+                    default -> interceptedMethod.unsupported();
+                };
             } else {
                 return validateReturnMicronautValidator(context, executableMethod);
             }

--- a/validation/src/test/groovy/io/micronaut/validation/ValidatedInterfaceSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/ValidatedInterfaceSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.validation
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import jakarta.validation.constraints.NotBlank
+import org.reactivestreams.Publisher
+import spock.lang.Issue
+import spock.lang.Specification
+
+class ValidatedInterfaceSpec extends Specification {
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/9418')
+    def 'error should be thrown directly'() {
+        given:
+        def ctx = ApplicationContext.run(['spec.name': 'ValidatedInterfaceSpec'])
+        def itf = ctx.getBean(MyInterface)
+
+        when:
+        itf.error("xyz")
+        then:
+        thrown IllegalStateException
+
+        cleanup:
+        ctx.close()
+    }
+
+    interface MyInterface {
+        Publisher<String> error(@NotBlank String someValue)
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "ValidatedInterfaceSpec")
+    static class MyImpl implements MyInterface {
+        @Override
+        Publisher<String> error(String someValue) {
+            throw new IllegalStateException()
+        }
+    }
+}


### PR DESCRIPTION
instead of wrapping them in a publisher.

I'm not sure why the original behavior was there, it doesn't seem to be tested.

An error publisher has worse error handling in the HTTP stack, leading to https://github.com/micronaut-projects/micronaut-core/issues/9418 . Prior to I think ebcd7c2eb217734fc572d6aa4c57515341e4a6c0, this was not hit by tests. That change removed the condition `hasValidationAnnotation(context)`, which caused the change in error handling.

Fixes https://github.com/micronaut-projects/micronaut-core/issues/9418