### PR TITLE
add a bean validation context to control property validation

### DIFF
--- a/validation/src/main/java/io/micronaut/validation/validator/BeanValidationContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/BeanValidationContext.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.validation.validator;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.beans.BeanProperty;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Context object to allow configuring validation behaviour.
+ */
+public interface BeanValidationContext {
+    /**
+     * The default validation context.
+     */
+    BeanValidationContext DEFAULT = new DefaultBeanValidationContext(List.of());
+
+    /**
+     * The validation groups.
+     * @return The groups
+     */
+    default List<Class<?>> groups() {
+        return List.of();
+    }
+
+    /**
+     * Create a validation context from the given groups.
+     * @param groups The groups
+     * @return The context
+     */
+    static @NonNull BeanValidationContext fromGroups(Class<?>... groups) {
+        return new DefaultBeanValidationContext(
+            groups != null ? Arrays.asList(groups) : List.of()
+        );
+    }
+
+    /**
+     * Hook to allow exclusion of properties during validation.
+     * @param object The object being validated
+     * @param property The property being validated.
+     * @return True if it should be validated.
+     * @param <T> The object type
+     */
+    default <T> boolean isPropertyValidated(
+        @NonNull T object, @NonNull BeanProperty<T, Object> property) {
+        return true;
+    }
+}

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultBeanValidationContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultBeanValidationContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.validation.validator;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.CollectionUtils;
+import java.util.List;
+
+/**
+ * A default implementation of {@link BeanValidationContext}.
+ * @param groups The groups
+ */
+@Internal
+record DefaultBeanValidationContext(
+    @NonNull
+    List<Class<?>> groups)
+    implements BeanValidationContext {
+    public DefaultBeanValidationContext {
+        if (CollectionUtils.isEmpty(groups)) {
+            groups = List.of();
+        }
+    }
+}

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
@@ -60,11 +60,11 @@ final class DefaultConstraintValidatorContext<R> implements ConstraintValidatorC
 
     private static final Map<Class<?>, List<Class<?>>> GROUP_SEQUENCES = new ConcurrentHashMap<>();
     private static final List<Class<?>> DEFAULT_GROUPS = Collections.singletonList(Default.class);
-    private final BeanValidationContext validationContext;
 
     boolean disableDefaultConstraintViolation;
     ConstraintDescriptor<Annotation> constraint;
 
+    private final BeanValidationContext validationContext;
     private final DefaultValidator defaultValidator;
     private final BeanIntrospection<R> beanIntrospection;
     private final R rootBean;

--- a/validation/src/main/java/io/micronaut/validation/validator/Validator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/Validator.java
@@ -22,6 +22,7 @@ import io.micronaut.core.beans.BeanIntrospection;
 import jakarta.validation.Constraint;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Valid;
+import jakarta.validation.ValidationException;
 import java.util.Set;
 
 /**
@@ -45,6 +46,7 @@ public interface Validator extends jakarta.validation.Validator {
 
     /**
      * Overridden variation that returns a {@link ExecutableMethodValidator}.
+     *
      * @return The validator
      */
     @Override
@@ -52,36 +54,115 @@ public interface Validator extends jakarta.validation.Validator {
 
     @Override
     @NonNull <T> Set<ConstraintViolation<T>> validate(
-            @NonNull T object,
-            Class<?>... groups
+        @NonNull T object,
+        Class<?>... groups
+    );
+
+    /**
+     * Validates all constraints on {@code object}.
+     *
+     * @param object            object to validate
+     * @param validationContext The context
+     * @param <T>               the type of the object to validate
+     * @return constraint violations or an empty set if none
+     * @throws IllegalArgumentException if object is {@code null}
+     *                                  or if {@code null} is passed to the varargs groups
+     * @throws ValidationException      if a non recoverable error happens
+     *                                  during the validation process
+     */
+    @NonNull <T> Set<ConstraintViolation<T>> validate(
+        @NonNull T object,
+        @NonNull BeanValidationContext validationContext
     );
 
     /**
      * Validate the given introspection and object.
+     *
      * @param introspection The introspection
-     * @param object The object
-     * @param groups The groups
-     * @param <T> The object type
+     * @param object        The object
+     * @param groups        The groups
+     * @param <T>           The object type
      * @return The constraint violations
      */
-    @NonNull
-    <T> Set<ConstraintViolation<T>> validate(
-            @NonNull BeanIntrospection<T> introspection,
-            @NonNull T object, @Nullable Class<?>... groups);
+    @NonNull <T> Set<ConstraintViolation<T>> validate(
+        @NonNull BeanIntrospection<T> introspection,
+        @NonNull T object, @Nullable Class<?>... groups);
+
+    /**
+     * Validate the given introspection and object.
+     *
+     * @param introspection The introspection
+     * @param object        The object
+     * @param context       The context
+     * @param <T>           The object type
+     * @return The constraint violations
+     */
+    @NonNull <T> Set<ConstraintViolation<T>> validate(
+        @NonNull BeanIntrospection<T> introspection,
+        @NonNull T object,
+        @NonNull BeanValidationContext context);
 
     @Override
     @NonNull <T> Set<ConstraintViolation<T>> validateProperty(
-            @NonNull T object,
-            @NonNull String propertyName,
-            Class<?>... groups
+        @NonNull T object,
+        @NonNull String propertyName,
+        Class<?>... groups
+    );
+
+    /**
+     * Validates all constraints placed on the property of {@code object}
+     * named {@code propertyName}.
+     *
+     * @param object       object to validate
+     * @param propertyName property to validate (i.e. field and getter constraints)
+     * @param context      The context
+     * @param <T>          the type of the object to validate
+     * @return constraint violations or an empty set if none
+     * @throws IllegalArgumentException if {@code object} is {@code null},
+     *                                  if {@code propertyName} is {@code null}, empty or not a valid object property
+     *                                  or if {@code null} is passed to the varargs groups
+     * @throws ValidationException      if a non recoverable error happens
+     *                                  during the validation process
+     */
+    @NonNull <T> Set<ConstraintViolation<T>> validateProperty(
+        @NonNull T object,
+        @NonNull String propertyName,
+        BeanValidationContext context
     );
 
     @Override
     @NonNull <T> Set<ConstraintViolation<T>> validateValue(
-            @NonNull Class<T> beanType,
-            @NonNull String propertyName,
-            @Nullable Object value,
-            Class<?>... groups
+        @NonNull Class<T> beanType,
+        @NonNull String propertyName,
+        @Nullable Object value,
+        Class<?>... groups
+    );
+
+    /**
+     * Validates all constraints placed on the property named {@code propertyName}
+     * of the class {@code beanType} would the property value be {@code value}.
+     * <p>
+     * {@link ConstraintViolation} objects return {@code null} for
+     * {@link ConstraintViolation#getRootBean()} and
+     * {@link ConstraintViolation#getLeafBean()}.
+     *
+     * @param beanType the bean type
+     * @param propertyName property to validate
+     * @param value property value to validate
+     * @param context The context
+     * @param <T> the type of the object to validate
+     * @return constraint violations or an empty set if none
+     * @throws IllegalArgumentException if {@code beanType} is {@code null},
+     *         if {@code propertyName} is {@code null}, empty or not a valid object property
+     *         or if {@code null} is passed to the varargs groups
+     * @throws ValidationException if a non recoverable error happens
+     *         during the validation process
+     */
+    @NonNull <T> Set<ConstraintViolation<T>> validateValue(
+        @NonNull Class<T> beanType,
+        @NonNull String propertyName,
+        @Nullable Object value,
+        BeanValidationContext context
     );
 
     /**
@@ -93,7 +174,7 @@ public interface Validator extends jakarta.validation.Validator {
      */
     static @NonNull Validator getInstance() {
         return new DefaultValidator(
-                new DefaultValidatorConfiguration()
+            new DefaultValidatorConfiguration()
         );
     }
 }

--- a/validation/src/test/groovy/io/micronaut/validation/BeanValidationContextSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/BeanValidationContextSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.validation
+
+import io.micronaut.core.beans.BeanProperty
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.validation.validator.BeanValidationContext
+import io.micronaut.validation.validator.Validator
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class BeanValidationContextSpec
+    extends Specification {
+
+    @Inject Validator validator
+
+    void "test skip validation of properties with custom context"() {
+        given:
+        Pojo pojo = new Pojo(email: "938r79l", name:"")
+
+        when:
+        def violations = validator.validate(
+                pojo,
+                new BeanValidationContext() {
+                    def boolean isPropertyValidated(Object object, BeanProperty<Object, Object> property) {
+                        return property.name == 'email'
+                    }
+                }
+        )
+
+        then:
+        violations.size() == 1
+    }
+
+    void "test don't skip validation of properties with default context"() {
+        given:
+        Pojo pojo = new Pojo(email: "938r79l", name:"")
+
+        when:
+        def violations = validator.validate(
+                pojo,
+                BeanValidationContext.DEFAULT
+        )
+
+        then:
+        violations.size() == 2
+    }
+}


### PR DESCRIPTION
Sometimes you need to control what properties are validated and there is no current API to do that.

The use case if partial updates. So you want to send a request that partially updates an object in the database so you need to validate only a subset of the properties. Currently you can kind of do this with groups but it is awkward and requires static declaration.

The PR adds a `BeanValidationContext` which can be used to control property inclusions and perhaps for other purposes in the future. The code that passed around the groups has been refactored to so with the context instead.