### PR TITLE
Ensure validators accessible as beans from usingContext

### DIFF
--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidatorFactory.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidatorFactory.java
@@ -75,8 +75,8 @@ public class DefaultValidatorFactory implements ValidatorFactory {
 
     @Override
     public ValidatorContext usingContext() {
-        if (configuration != null && configuration instanceof ValidatorContext) {
-            return (ValidatorContext) configuration;
+        if (configuration instanceof ValidatorContext validatorContext) {
+            return validatorContext;
         } else {
             DefaultValidatorConfiguration newValidatorConfiguration = new DefaultValidatorConfiguration();
             newValidatorConfiguration.setBeanIntrospector(configuration.getBeanIntrospector());

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidatorFactory.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidatorFactory.java
@@ -75,9 +75,13 @@ public class DefaultValidatorFactory implements ValidatorFactory {
 
     @Override
     public ValidatorContext usingContext() {
-        DefaultValidatorConfiguration newValidatorConfiguration = new DefaultValidatorConfiguration();
-        newValidatorConfiguration.setBeanIntrospector(configuration.getBeanIntrospector());
-        return newValidatorConfiguration;
+        if (configuration != null && configuration instanceof ValidatorContext) {
+            return (ValidatorContext) configuration;
+        } else {
+            DefaultValidatorConfiguration newValidatorConfiguration = new DefaultValidatorConfiguration();
+            newValidatorConfiguration.setBeanIntrospector(configuration.getBeanIntrospector());
+            return newValidatorConfiguration;
+        }
     }
 
     @Override


### PR DESCRIPTION
The `usingContext` method of `DefaultValidatorFactory` is updated to check for an existing non-null `ValidatorConfiguration` that is itself an instance of `ValidatorContext` (which will always be the case when created via DI) and return that instead of creating a new instance.

This allows custom validation constraints to be located in the `BeanContext` when validation is invoked by a Jakarta validation implementation.

Resolves #263 
