### PR TITLE
Validator optimizations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,3 +57,6 @@ gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 gradle-kotlin-allopen = { module = "org.jetbrains.kotlin:kotlin-allopen", version.ref = "kotlin-gradle-plugin" }
 gradle-kotlin-noarg = { module = "org.jetbrains.kotlin:kotlin-noarg", version.ref = "kotlin-gradle-plugin" }
 gradle-ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp-gradle-plugin" }
+
+[plugins]
+jmh = { id = "me.champeau.jmh", version = "0.7.3" }

--- a/validation/build.gradle
+++ b/validation/build.gradle
@@ -46,3 +46,7 @@ spotless {
     }
 }
 
+tasks.getByName("checkstyleJmh").configure {
+    enabled = false
+}
+

--- a/validation/build.gradle
+++ b/validation/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "io.micronaut.build.internal.validation-module"
+    alias(libs.plugins.jmh)
 }
 
 dependencies {
@@ -33,6 +34,10 @@ dependencies {
 
     testImplementation(mnTest.micronaut.test.junit5)
     testRuntimeOnly(libs.junit.jupiter.engine)
+
+    jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.36")
+    jmhAnnotationProcessor(projects.micronautValidationProcessor)
+    jmhAnnotationProcessor(mn.micronaut.inject.java)
 }
 
 spotless {

--- a/validation/src/jmh/java/io/micronaut/validation/ParameterBenchmark.java
+++ b/validation/src/jmh/java/io/micronaut/validation/ParameterBenchmark.java
@@ -1,0 +1,77 @@
+package io.micronaut.validation;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import jakarta.validation.constraints.NotBlank;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class ParameterBenchmark {
+    private ApplicationContext ctx;
+    private MyBean bean;
+
+    public static void main(String[] args) throws RunnerException {
+        ParameterBenchmark test = new ParameterBenchmark();
+        test.init();
+        try {
+            test.string(new Blackhole("Today's password is swordfish. I understand instantiating Blackholes directly is dangerous."));
+        } finally {
+            test.destroy();
+        }
+
+        Options opt = new OptionsBuilder()
+            .include(".*" + ParameterBenchmark.class.getSimpleName() + ".*")
+            //.addProfiler(AsyncProfiler.class, "libPath=/home/yawkat/bin/async-profiler-4.1-linux-x64/lib/libasyncProfiler.so;output=flamegraph")
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void init() {
+        ctx = ApplicationContext.run(Map.of("spec.name", "ParameterBenchmark"));
+        bean = ctx.getBean(MyBean.class);
+    }
+
+    @TearDown
+    public void destroy() {
+        ctx.close();
+    }
+
+    @Benchmark
+    public void string(Blackhole blackhole) {
+        bean.string(blackhole, "foo");
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "ParameterBenchmark")
+    static class MyBean {
+        void string(Blackhole blackhole, @NotBlank String string) {
+            blackhole.consume(string);
+        }
+    }
+}

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
@@ -240,28 +240,27 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
                 if (Arrays.stream(classGroupSequence).noneMatch(c -> c == beanIntrospection.getBeanType())) {
                     throw new GroupDefinitionException("Group sequence is missing default group defined by the class of: " + beanIntrospection.getBeanType());
                 }
-                return Arrays.stream(classGroupSequence)
-                    .flatMap(group -> {
-                        if (group == beanIntrospection.getBeanType()) {
-                            return Stream.of(new ValidationGroup(true, true, List.of(Default.class)));
-                        }
-                        return findGroupSequence(Collections.singletonList(group), new HashSet<>()).stream();
-                    })
-                    .toList();
+                List<ValidationGroup> dest = new ArrayList<>();
+                for (Class<Object> group : classGroupSequence) {
+                    if (group == beanIntrospection.getBeanType()) {
+                        dest.add(new ValidationGroup(true, true, List.of(Default.class)));
+                    } else {
+                        findGroups(dest, List.of(group), new HashSet<>());
+                    }
+                }
+                return dest;
             }
         }
-        return findGroupSequence(definedGroups, new HashSet<>());
+        return findGroupSequences();
     }
 
     public List<ValidationGroup> findGroupSequences() {
-        return findGroupSequence(definedGroups, new HashSet<>());
+        List<ValidationGroup> dest = new ArrayList<>();
+        findGroups(dest, definedGroups, new HashSet<>());
+        return dest;
     }
 
-    private List<ValidationGroup> findGroupSequence(List<Class<?>> groups, Set<Class<?>> processedGroups) {
-        return findGroups(groups, processedGroups).stream().toList();
-    }
-
-    private List<ValidationGroup> findGroups(Class<?> group, Set<Class<?>> processedGroups) {
+    private void findGroups(List<ValidationGroup> dest, Class<?> group, Set<Class<?>> processedGroups) {
         if (convertedGroups != null) {
             group = convertGroup(group);
         }
@@ -275,10 +274,17 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
                 .toList();
         });
         if (groupSequence.isEmpty()) {
-            return List.of(new ValidationGroup(false, false, List.of(group)));
+            dest.add(new ValidationGroup(false, false, List.of(group)));
+            return;
         }
-        return groupSequence.stream()
-            .flatMap(g -> findGroups(g, processedGroups).stream().map(vg -> new ValidationGroup(true, true, vg.groups))).toList();
+        int start = dest.size();
+        for (Class<?> g : groupSequence) {
+            findGroups(dest, g, processedGroups);
+        }
+        for (int i = start; i < groupSequence.size(); i++) {
+            ValidationGroup vg = dest.get(i);
+            dest.set(i, new ValidationGroup(true, true, vg.groups));
+        }
     }
 
     private Class<?> convertGroup(Class<?> group) {
@@ -289,18 +295,24 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
         return newGroup;
     }
 
-    private List<ValidationGroup> findGroups(List<Class<?>> groupSequence, Set<Class<?>> processedGroups) {
-        List<ValidationGroup> innerGroups = groupSequence.stream().flatMap(g -> findGroups(g, processedGroups).stream()).toList();
-        if (innerGroups.stream().noneMatch(validationGroup -> validationGroup.isSequence)) {
-            return List.of(
-                new ValidationGroup(
-                    false,
-                    false,
-                    innerGroups.stream().flatMap(validationGroup -> validationGroup.groups.stream()).toList()
-                )
-            );
+    private void findGroups(List<ValidationGroup> dest, List<Class<?>> groupSequence, Set<Class<?>> processedGroups) {
+        int start = dest.size();
+        for (Class<?> g : groupSequence) {
+            findGroups(dest, g, processedGroups);
         }
-        return innerGroups;
+        boolean anySequence = false;
+        for (int i = start; i < groupSequence.size() && !anySequence; i++) {
+            anySequence |= dest.get(i).isSequence;
+        }
+        if (!anySequence) {
+            List<ValidationGroup> subList = dest.subList(start, dest.size());
+            List<Class<?>> copy = new ArrayList<>();
+            for (ValidationGroup validationGroup : subList) {
+                copy.addAll(validationGroup.groups);
+            }
+            subList.clear();
+            dest.add(new ValidationGroup(false, false, copy));
+        }
     }
 
     public void addViolation(DefaultConstraintViolation<R> violation) {

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
@@ -237,6 +237,19 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
         };
     }
 
+    List<DefaultConstraintValidatorContext.ValidationGroup> findGroupSequences(@Nullable Object bean) {
+        if (bean == null) {
+            return findGroupSequences();
+        } else {
+            BeanIntrospection<?> beanIntrospection = defaultValidator.getBeanIntrospection(bean);
+            if (beanIntrospection == null) {
+                return findGroupSequences();
+            } else {
+                return findGroupSequences(beanIntrospection);
+            }
+        }
+    }
+
     public List<ValidationGroup> findGroupSequences(BeanIntrospection<?> beanIntrospection) {
         FindGroupContext ctx = new FindGroupContext(defaultValidator, convertedGroups, definedGroups);
         if (ctx.isDefault()) {

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
@@ -83,7 +83,7 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
     private Object executableReturnValue;
     private List<Class<?>> currentGroups;
     private Map<Class<?>, Class<?>> convertedGroups = Collections.emptyMap();
-    private Set<ConstraintViolation<R>> currentViolations = new LinkedHashSet<>();
+    private boolean hasCurrentViolations = false;
 
     DefaultConstraintValidatorContext(DefaultValidator defaultValidator, BeanIntrospection<R> beanIntrospection, R rootBean, BeanValidationContext validationContext) {
         this(defaultValidator, beanIntrospection, validationContext, rootBean, null, new ValidationPath(), new LinkedHashSet<>(), null, Collections.emptyList());
@@ -186,9 +186,9 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
 
     public GroupsValidation withGroupSequence(@NonNull ValidationGroup validationGroup) {
         List<Class<?>> prevGroups = currentGroups;
-        Set<ConstraintViolation<R>> prevViolations = currentViolations;
+        boolean prevViolations = hasCurrentViolations;
         currentGroups = validationGroup.groups();
-        currentViolations = new LinkedHashSet<>();
+        hasCurrentViolations = false;
 
         return new GroupsValidation() {
 
@@ -200,13 +200,13 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
                 if (validationGroup.isRedefinedDefaultGroupSequence()) {
                     return !overallViolations.isEmpty();
                 }
-                return !currentViolations.isEmpty();
+                return hasCurrentViolations;
             }
 
             @Override
             public void close() {
                 currentGroups = prevGroups;
-                currentViolations = prevViolations;
+                hasCurrentViolations = prevViolations;
             }
         };
     }
@@ -304,9 +304,7 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
     }
 
     public void addViolation(DefaultConstraintViolation<R> violation) {
-        if (currentViolations != null) {
-            currentViolations.add(violation);
-        }
+        hasCurrentViolations = true;
         overallViolations.add(violation);
     }
 

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
@@ -48,7 +48,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * The implementation of {@link ConstraintValidatorContext}.
@@ -152,7 +151,12 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
         if (currentGroups.contains(Default.class) && rootClass != null && constraintGroups.contains(rootClass)) {
             return true;
         }
-        return currentGroups.stream().anyMatch(constraintGroups::contains);
+        for (Class<?> group : currentGroups) {
+            if (constraintGroups.contains(group)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Object[] getExecutableParameterValues() {

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
@@ -143,7 +143,7 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
         }
     }
 
-    public boolean hasDefaultGroup() {
+    private static boolean hasDefaultGroup(List<Class<?>> definedGroups) {
         return definedGroups.equals(DEFAULT_GROUPS);
     }
 
@@ -230,7 +230,7 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
             av -> av.classValue("to").orElseThrow())
         );
         convertedGroups.putAll(newConvertGroups);
-        currentGroups = prevGroups.stream().<Class<?>>map(this::convertGroup).toList();
+        currentGroups = prevGroups.stream().<Class<?>>map(c -> convertGroup(convertedGroups, c)).toList();
         return () -> {
             convertedGroups = prevConvertedGroups;
             currentGroups = prevGroups;
@@ -238,7 +238,16 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
     }
 
     public List<ValidationGroup> findGroupSequences(BeanIntrospection<?> beanIntrospection) {
-        if (hasDefaultGroup()) {
+        FindGroupContext ctx = new FindGroupContext(defaultValidator, convertedGroups, definedGroups);
+        if (ctx.isDefault()) {
+            return defaultValidator.findGroupSequencesCache.computeIfAbsent(beanIntrospection, bi -> List.copyOf(findGroupSequences(ctx, bi)));
+        } else {
+            return findGroupSequences(ctx, beanIntrospection);
+        }
+    }
+
+    private static List<ValidationGroup> findGroupSequences(FindGroupContext ctx, BeanIntrospection<?> beanIntrospection) {
+        if (hasDefaultGroup(ctx.definedGroups)) {
             Class<Object>[] classGroupSequence = beanIntrospection.classValues(GroupSequence.class);
             if (classGroupSequence.length > 0) {
                 if (Arrays.stream(classGroupSequence).noneMatch(c -> c == beanIntrospection.getBeanType())) {
@@ -249,31 +258,40 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
                     if (group == beanIntrospection.getBeanType()) {
                         dest.add(new ValidationGroup(true, true, List.of(Default.class)));
                     } else {
-                        findGroups(dest, List.of(group), new HashSet<>());
+                        findGroups(ctx, dest, List.of(group), new HashSet<>());
                     }
                 }
                 return dest;
             }
         }
-        return findGroupSequences();
+        return findGroupSequences(ctx);
     }
 
     public List<ValidationGroup> findGroupSequences() {
+        FindGroupContext ctx = new FindGroupContext(defaultValidator, convertedGroups, definedGroups);
+        if (ctx.isDefault()) {
+            return defaultValidator.findGroupSequencesCache.computeIfAbsent(null, ignored -> List.copyOf(findGroupSequences(ctx)));
+        } else {
+            return findGroupSequences(ctx);
+        }
+    }
+
+    private static List<ValidationGroup> findGroupSequences(FindGroupContext ctx) {
         List<ValidationGroup> dest = new ArrayList<>();
-        findGroups(dest, definedGroups, new HashSet<>());
+        findGroups(ctx, dest, ctx.definedGroups, new HashSet<>());
         return dest;
     }
 
-    private void findGroups(List<ValidationGroup> dest, Class<?> group, Set<Class<?>> processedGroups) {
-        if (convertedGroups != null) {
-            group = convertGroup(group);
+    private static void findGroups(FindGroupContext ctx, List<ValidationGroup> dest, Class<?> group, Set<Class<?>> processedGroups) {
+        if (ctx.convertedGroups != null) {
+            group = convertGroup(ctx.convertedGroups, group);
         }
         if (!processedGroups.add(group)) {
             throw new GroupDefinitionException("Cyclical group: " + group);
         }
         Class<?> finalGroup = group;
         List<Class<?>> groupSequence = GROUP_SEQUENCES.computeIfAbsent(group, ignore -> {
-            return defaultValidator.getBeanIntrospector().findIntrospection(finalGroup).stream()
+            return ctx.defaultValidator.getBeanIntrospector().findIntrospection(finalGroup).stream()
                 .<Class<?>>flatMap(introspection -> Arrays.stream(introspection.classValues(GroupSequence.class)))
                 .toList();
         });
@@ -283,7 +301,7 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
         }
         int start = dest.size();
         for (Class<?> g : groupSequence) {
-            findGroups(dest, g, processedGroups);
+            findGroups(ctx, dest, g, processedGroups);
         }
         for (int i = start; i < groupSequence.size(); i++) {
             ValidationGroup vg = dest.get(i);
@@ -291,7 +309,7 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
         }
     }
 
-    private Class<?> convertGroup(Class<?> group) {
+    private static Class<?> convertGroup(Map<Class<?>, Class<?>> convertedGroups, Class<?> group) {
         Class<?> newGroup = convertedGroups.get(group);
         if (newGroup == null) {
             return group;
@@ -299,10 +317,10 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
         return newGroup;
     }
 
-    private void findGroups(List<ValidationGroup> dest, List<Class<?>> groupSequence, Set<Class<?>> processedGroups) {
+    private static void findGroups(FindGroupContext ctx, List<ValidationGroup> dest, List<Class<?>> groupSequence, Set<Class<?>> processedGroups) {
         int start = dest.size();
         for (Class<?> g : groupSequence) {
-            findGroups(dest, g, processedGroups);
+            findGroups(ctx, dest, g, processedGroups);
         }
         boolean anySequence = false;
         for (int i = start; i < groupSequence.size() && !anySequence; i++) {
@@ -407,5 +425,15 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
     @Internal
     record ValidationGroup(boolean isSequence, boolean isRedefinedDefaultGroupSequence,
                            List<Class<?>> groups) {
+    }
+
+    private record FindGroupContext(
+        DefaultValidator defaultValidator,
+        Map<Class<?>, Class<?>> convertedGroups,
+        List<Class<?>> definedGroups
+    ) {
+        boolean isDefault() {
+            return definedGroups == DEFAULT_GROUPS && convertedGroups.isEmpty();
+        }
     }
 }

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintViolationBuilder.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintViolationBuilder.java
@@ -48,13 +48,13 @@ final class DefaultConstraintViolationBuilder<R> implements ConstraintValidatorC
         this.constraintValidatorContext = constraintValidatorContext;
         this.messageInterpolator = messageInterpolator;
         this.validationPath = new ValidationPath(constraintValidatorContext.getCurrentPath());
-        Path.Node last = validationPath.nodes.peekLast();
+        Path.Node last = validationPath.peekLast();
         ElementKind kind = last == null ? null : last.getKind();
         if (kind == ElementKind.CROSS_PARAMETER) {
-            validationPath.nodes.pollLast();
+            validationPath.removeLast();
         }
         if (kind == ElementKind.BEAN) {
-            Path.Node node = validationPath.nodes.pollLast();
+            Path.Node node = validationPath.removeLast();
             ValidationPath.DefaultNode defaultNode = (ValidationPath.DefaultNode) node;
             next = new ValidationPath.MutableContainerContext(defaultNode.containerContext);
         }
@@ -99,7 +99,7 @@ final class DefaultConstraintViolationBuilder<R> implements ConstraintValidatorC
 
     @Override
     public NodeBuilderDefinedContext addParameterNode(int index) {
-        Path.Node node = validationPath.nodes.peekLast();
+        Path.Node node = validationPath.peekLast();
         if (node == null || node.getKind() != ElementKind.METHOD) {
             throw new IllegalStateException("Cannot add parameter at path kind: " + (node == null ? "null" : node.getKind()));
         }

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -502,17 +502,7 @@ public class DefaultValidator implements
         try (DefaultConstraintValidatorContext.ValidationCloseable ignored1 = context.withExecutableReturnValue(returnValue)) {
             try (ValidationPath.ContextualPath ignored2 = context.getCurrentPath().addMethodNode(executableMethod)) {
                 try (ValidationPath.ContextualPath ignored3 = context.getCurrentPath().addReturnValueNode()) {
-                    List<DefaultConstraintValidatorContext.ValidationGroup> groupSequences;
-                    if (bean == null) {
-                        groupSequences = context.findGroupSequences();
-                    } else {
-                        BeanIntrospection<T> beanIntrospection = getBeanIntrospection(bean);
-                        if (beanIntrospection == null) {
-                            groupSequences = context.findGroupSequences();
-                        } else {
-                            groupSequences = context.findGroupSequences(beanIntrospection);
-                        }
-                    }
+                    List<DefaultConstraintValidatorContext.ValidationGroup> groupSequences = context.findGroupSequences(bean);
 
                     boolean canCascade = true;
                     for (DefaultConstraintValidatorContext.ValidationGroup groupSequence : groupSequences) {
@@ -940,17 +930,7 @@ public class DefaultValidator implements
                                                 @NonNull Argument<?>[] arguments,
                                                 int argLen) {
 
-        List<DefaultConstraintValidatorContext.ValidationGroup> groupSequences;
-        if (bean == null) {
-            groupSequences = context.findGroupSequences();
-        } else {
-            BeanIntrospection<T> beanIntrospection = getBeanIntrospection(bean);
-            if (beanIntrospection == null) {
-                groupSequences = context.findGroupSequences();
-            } else {
-                groupSequences = context.findGroupSequences(beanIntrospection);
-            }
-        }
+        List<DefaultConstraintValidatorContext.ValidationGroup> groupSequences = context.findGroupSequences(bean);
         boolean canCascade = true;
         for (DefaultConstraintValidatorContext.ValidationGroup groupSequence : groupSequences) {
             try (DefaultConstraintValidatorContext.GroupsValidation validation = context.withGroupSequence(groupSequence)) {

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -116,6 +116,7 @@ public class DefaultValidator implements
     };
 
     final MessageInterpolator messageInterpolator;
+    final ConcurrentMap<BeanIntrospection<?>, List<DefaultConstraintValidatorContext.ValidationGroup>> findGroupSequencesCache = new CopyOnWriteMap<>(16 * 1024);
 
     private final ConstraintValidatorRegistry constraintValidatorRegistry;
     private final ClockProvider clockProvider;

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1498,22 +1498,24 @@ public class DefaultValidator implements
 
     private <R> List<DefaultConstraintDescriptor<Annotation>> getConstraints(DefaultConstraintValidatorContext<R> context,
                                                                              AnnotationMetadata annotationMetadata) {
-        return annotationMetadata.getAnnotationTypesByStereotype(Constraint.class)
-            .stream().
-            flatMap(constraintType -> {
-                List<? extends AnnotationValue<? extends Annotation>> annotationValuesByType = annotationMetadata.getAnnotationValuesByType(constraintType);
-                if (annotationValuesByType.isEmpty()) {
-                    annotationValuesByType = annotationMetadata.getDeclaredAnnotationValuesByType(constraintType);
+        List<DefaultConstraintDescriptor<Annotation>> descriptors = new ArrayList<>();
+        for (Class<? extends Annotation> constraintType : annotationMetadata.getAnnotationTypesByStereotype(Constraint.class)) {
+            List<? extends AnnotationValue<? extends Annotation>> annotationValuesByType = annotationMetadata.getAnnotationValuesByType(constraintType);
+            if (annotationValuesByType.isEmpty()) {
+                annotationValuesByType = annotationMetadata.getDeclaredAnnotationValuesByType(constraintType);
+            }
+            for (AnnotationValue<? extends Annotation> annotationValue : annotationValuesByType) {
+                DefaultConstraintDescriptor<Annotation> descriptor = new DefaultConstraintDescriptor<>(
+                    (Class<Annotation>) constraintType,
+                    (AnnotationValue<Annotation>) annotationValue,
+                    annotationMetadata
+                );
+                if (isConstraintIncluded(context, descriptor)) {
+                    descriptors.add(descriptor);
                 }
-                return annotationValuesByType.stream()
-                    .map(annotationValue -> new DefaultConstraintDescriptor<>(
-                        (Class<Annotation>) constraintType,
-                        (AnnotationValue<Annotation>) annotationValue,
-                        annotationMetadata
-                    ))
-                    .filter(annotationValue -> isConstraintIncluded(context, annotationValue));
-            })
-            .toList();
+            }
+        }
+        return descriptors;
     }
 
     private <R> String buildMessageTemplate(DefaultConstraintValidatorContext<R> context,

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -39,6 +39,7 @@ import io.micronaut.core.type.MutableArgumentValue;
 import io.micronaut.core.type.ReturnType;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.CopyOnWriteMap;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
 import io.micronaut.inject.ExecutableMethod;
@@ -89,6 +90,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -124,6 +126,12 @@ public class DefaultValidator implements
     private final BeanIntrospector beanIntrospector;
     private final InternalConstraintValidatorFactory constraintValidatorFactory;
     private final boolean isPrependPropertyPath;
+
+    // The advantage of CopyOnWriteMap over ConcurrentHashMap is that here we can define a maximum
+    // size after which entries are evicted. This can save us from a memory leak if we cache more
+    // than we should. We still set it comfortably high to avoid unnecessary evictions.
+    private final ConcurrentMap<AnnotationMetadata, List<DefaultConstraintDescriptor<Annotation>>> constraintCache =
+        new CopyOnWriteMap<>(65536);
 
     /**
      * Default constructor.
@@ -510,17 +518,19 @@ public class DefaultValidator implements
                         try (DefaultConstraintValidatorContext.GroupsValidation validation = context.withGroupSequence(groupSequence)) {
                             // Strip class annotations
                             AnnotationMetadata returnAm = returnType.asArgument().getAnnotationMetadata();
+                            boolean cacheConstraints = true;
                             if (returnAm instanceof AnnotationMetadataHierarchy annotationMetadataHierarchy) {
                                 if (returnAm.getDeclaredMetadata() instanceof AnnotationMetadataHierarchy) {
                                     returnAm = new AnnotationMetadataHierarchy(
                                         annotationMetadataHierarchy.getRootMetadata(),
                                         annotationMetadataHierarchy.getDeclaredMetadata().getDeclaredMetadata()
                                     );
+                                    cacheConstraints = false;
                                 } else {
                                     returnAm = annotationMetadataHierarchy.getDeclaredMetadata();
                                 }
                             }
-                            visitElement(context, bean, returnType.asArgument(), returnAm, returnValue, canCascade, false);
+                            visitElement(context, bean, returnType.asArgument(), returnAm, returnValue, canCascade, false, cacheConstraints);
 
                             if (validation.isFailed()) {
                                 return context.getOverallViolations();
@@ -946,7 +956,7 @@ public class DefaultValidator implements
 
                 if (methodAnnotationMetadata.hasStereotype(Constraint.class)) {
                     try (ValidationPath.ContextualPath ignored = context.getCurrentPath().addCrossParameterNode()) {
-                        validateConstrains(context, bean, Argument.of(Object[].class, methodAnnotationMetadata), parameters);
+                        validateConstrains(context, bean, Argument.of(Object[].class, methodAnnotationMetadata), parameters, true);
                     }
                 }
 
@@ -981,7 +991,8 @@ public class DefaultValidator implements
                                 argument,
                                 parameterValue,
                                 canCascade,
-                                false
+                                false,
+                                true
                             );
                         }
                     }
@@ -1129,7 +1140,8 @@ public class DefaultValidator implements
                                      Argument<E> elementArgument,
                                      E elementValue,
                                      boolean canCascade,
-                                     boolean needsCanCascadeCheck) {
+                                     boolean needsCanCascadeCheck,
+                                     boolean cacheConstraints) {
         AnnotationMetadata annotationMetadata = elementArgument.getAnnotationMetadata();
         visitElement(context,
             bean,
@@ -1137,7 +1149,8 @@ public class DefaultValidator implements
             annotationMetadata,
             elementValue,
             canCascade,
-            needsCanCascadeCheck
+            needsCanCascadeCheck,
+            cacheConstraints
         );
     }
 
@@ -1147,7 +1160,8 @@ public class DefaultValidator implements
                                      AnnotationMetadata annotationMetadata,
                                      E elementValue,
                                      boolean canCascade,
-                                     boolean needsCanCascadeCheck) {
+                                     boolean needsCanCascadeCheck,
+                                     boolean cacheConstraints) {
         visitElement(context,
             bean,
             elementArgument,
@@ -1155,7 +1169,8 @@ public class DefaultValidator implements
             elementValue,
             canCascade,
             canCascade && annotationMetadata.hasStereotype(Valid.class),
-            needsCanCascadeCheck
+            needsCanCascadeCheck,
+            cacheConstraints
         );
     }
 
@@ -1166,9 +1181,10 @@ public class DefaultValidator implements
                                      E elementValue,
                                      boolean canCascade,
                                      boolean hasValid,
-                                     boolean needsCanCascadeCheck) {
+                                     boolean needsCanCascadeCheck,
+                                     boolean cacheConstraints) {
 
-        List<DefaultConstraintDescriptor<Annotation>> constraints = getConstraints(context, annotationMetadata);
+        List<DefaultConstraintDescriptor<Annotation>> constraints = getConstraints(context, annotationMetadata, cacheConstraints);
 
         if (visitContainer(context, leftBean, elementArgument, annotationMetadata, elementValue, constraints, canCascade)) {
             return;
@@ -1318,7 +1334,9 @@ public class DefaultValidator implements
                             value,
                             canCascade,
                             containerValueArgument.getAnnotationMetadata().hasStereotype(Valid.class) || isLegacyValid,
-                            true);
+                            true,
+                            false // might be possible to cache, investigate if there's a perf problem here
+                        );
                     }
 
                     private <RX, EX> void validateContainerValue(DefaultConstraintValidatorContext<RX> context,
@@ -1375,9 +1393,10 @@ public class DefaultValidator implements
     private <R, E> void validateConstrains(DefaultConstraintValidatorContext<R> context,
                                            @Nullable Object leftBean,
                                            @NonNull Argument<E> elementArgument,
-                                           @Nullable E elementValue) {
+                                           @Nullable E elementValue,
+                                           boolean cacheConstraints) {
         AnnotationMetadata annotationMetadata = elementArgument.getAnnotationMetadata();
-        List<DefaultConstraintDescriptor<Annotation>> constraints = getConstraints(context, annotationMetadata);
+        List<DefaultConstraintDescriptor<Annotation>> constraints = getConstraints(context, annotationMetadata, cacheConstraints);
         validateConstrains(context, leftBean, elementArgument, elementValue, constraints);
     }
 
@@ -1497,7 +1516,22 @@ public class DefaultValidator implements
     }
 
     private <R> List<DefaultConstraintDescriptor<Annotation>> getConstraints(DefaultConstraintValidatorContext<R> context,
-                                                                             AnnotationMetadata annotationMetadata) {
+                                                                             AnnotationMetadata annotationMetadata,
+                                                                             boolean cache) {
+        if (cache) {
+            List<DefaultConstraintDescriptor<Annotation>> cached = constraintCache.computeIfAbsent(annotationMetadata, m -> getConstraints0(null, m));
+            if (!cached.isEmpty()) {
+                cached = new ArrayList<>(cached);
+                cached.removeIf(descriptor -> !isConstraintIncluded(context, descriptor));
+            }
+            return cached;
+        } else {
+            return getConstraints0(context, annotationMetadata);
+        }
+    }
+
+    private <R> List<DefaultConstraintDescriptor<Annotation>> getConstraints0(@Nullable DefaultConstraintValidatorContext<R> context,
+                                                                              AnnotationMetadata annotationMetadata) {
         List<DefaultConstraintDescriptor<Annotation>> descriptors = new ArrayList<>();
         for (Class<? extends Annotation> constraintType : annotationMetadata.getAnnotationTypesByStereotype(Constraint.class)) {
             List<? extends AnnotationValue<? extends Annotation>> annotationValuesByType = annotationMetadata.getAnnotationValuesByType(constraintType);
@@ -1510,7 +1544,7 @@ public class DefaultValidator implements
                     (AnnotationValue<Annotation>) annotationValue,
                     annotationMetadata
                 );
-                if (isConstraintIncluded(context, descriptor)) {
+                if (context == null || isConstraintIncluded(context, descriptor)) {
                     descriptors.add(descriptor);
                 }
             }

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -1218,8 +1218,13 @@ public class DefaultValidator implements
             || Object[].class.isAssignableFrom(containerArgument.getType())
         );
 
-        final List<DefaultConstraintDescriptor<Annotation>> skipUnwrappingConstraints = constraints.stream().filter(c -> c.getValueUnwrapping() == ValidateUnwrappedValue.SKIP).toList();
-        final List<DefaultConstraintDescriptor<Annotation>> explicitUnwrappingConstraints = constraints.stream().filter(c -> c.getValueUnwrapping() == ValidateUnwrappedValue.UNWRAP).toList();
+        boolean anyExplicitUnwrapping = false;
+        for (DefaultConstraintDescriptor<Annotation> constraint : constraints) {
+            if (constraint.getValueUnwrapping() == ValidateUnwrappedValue.UNWRAP) {
+                anyExplicitUnwrapping = true;
+                break;
+            }
+        }
 
         List<ValueExtractorDefinition<E>> valueExtractorDefinitions = valueExtractorRegistry.findValueExtractors(containerArgument.getType());
         if (valueExtractorDefinitions.isEmpty()) {
@@ -1230,38 +1235,56 @@ public class DefaultValidator implements
                     (ValueExtractorDefinition<E>) new ValueExtractorDefinition<>(Object[].class, Object.class, null, false, LEGACY_ARRAY_EXTRACTOR)
                 );
             } else {
-                if (!explicitUnwrappingConstraints.isEmpty()) {
+                if (anyExplicitUnwrapping) {
                     throw new ConstraintDeclarationException("Cannot unwrap the constraint no extractors are present!");
                 }
                 return false;
             }
         }
 
-        if (!explicitUnwrappingConstraints.isEmpty() && valueExtractorDefinitions.size() > 1) {
+        if (anyExplicitUnwrapping && valueExtractorDefinitions.size() > 1) {
             throw new ConstraintDeclarationException("Cannot unwrap the constraint when multiple value extractors are present!");
         }
 
-        long unwrappedCount = valueExtractorDefinitions.stream().filter(ValueExtractorDefinition::unwrapByDefault).count();
-        if (unwrappedCount > 1) {
-            throw new ConstraintDeclarationException("Multiple unwrap by default value extractors aren't allowed!");
+        ValueExtractorDefinition<E> singleUnwrapByDefault = null;
+        for (ValueExtractorDefinition<E> definition : valueExtractorDefinitions) {
+            if (definition.unwrapByDefault()) {
+                if (singleUnwrapByDefault != null) {
+                    throw new ConstraintDeclarationException("Multiple unwrap by default value extractors aren't allowed!");
+                }
+                singleUnwrapByDefault = definition;
+            }
         }
 
         List<DefaultConstraintDescriptor<Annotation>> containerElementConstraints;
 
-        if (unwrappedCount > 0) {
-            if (valueExtractorDefinitions.size() != unwrappedCount) {
+        if (singleUnwrapByDefault != null) {
+            if (valueExtractorDefinitions.size() != 1) {
                 // Only allow one unwrapped by default value extractor
-                valueExtractorDefinitions = valueExtractorDefinitions.stream().filter(ValueExtractorDefinition::unwrapByDefault).toList();
+                valueExtractorDefinitions = List.of(singleUnwrapByDefault);
             }
-            containerElementConstraints = new ArrayList<>(constraints);
-            containerElementConstraints.removeAll(skipUnwrappingConstraints);
+            containerElementConstraints = new ArrayList<>();
+            List<DefaultConstraintDescriptor<Annotation>> skipUnwrappingConstraints = new ArrayList<>();
+            for (DefaultConstraintDescriptor<Annotation> constraint : constraints) {
+                if (constraint.getValueUnwrapping() == ValidateUnwrappedValue.SKIP) {
+                    skipUnwrappingConstraints.add(constraint);
+                } else {
+                    containerElementConstraints.add(constraint);
+                }
+            }
 
             validateConstrains(context, leftBean, containerArgument, containerValue, skipUnwrappingConstraints);
         } else {
-            containerElementConstraints = explicitUnwrappingConstraints;
+            containerElementConstraints = new ArrayList<>();
 
-            List<DefaultConstraintDescriptor<Annotation>> containerConstraints = new ArrayList<>(constraints);
-            containerConstraints.removeAll(explicitUnwrappingConstraints);
+            List<DefaultConstraintDescriptor<Annotation>> containerConstraints = new ArrayList<>();
+            for (DefaultConstraintDescriptor<Annotation> constraint : constraints) {
+                if (constraint.getValueUnwrapping() == ValidateUnwrappedValue.UNWRAP) {
+                    containerElementConstraints.add(constraint);
+                } else {
+                    containerConstraints.add(constraint);
+                }
+            }
 
             validateConstrains(context, leftBean, containerArgument, containerValue, containerConstraints);
         }

--- a/validation/src/main/java/io/micronaut/validation/validator/ValidationPath.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/ValidationPath.java
@@ -26,10 +26,9 @@ import jakarta.validation.ElementKind;
 import jakarta.validation.Path;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -38,16 +37,16 @@ import java.util.List;
  * @author Denis Stepanov
  * @since 4.0.0
  */
+// opportunistically extend ArrayList
 @Internal
-final class ValidationPath implements Path {
+final class ValidationPath extends ArrayList<Path.Node> implements Path {
 
-    final Deque<Node> nodes;
     private ContainerContext containerContext = DefaultContainerContext.NONE;
 
     private final ContextualPath popPath = new ContextualPath() {
         @Override
         public void close() {
-            nodes.removeLast();
+            removeLast();
         }
     };
 
@@ -57,22 +56,25 @@ final class ValidationPath implements Path {
      * @param nodes The nodes
      */
     ValidationPath(ValidationPath nodes) {
-        this.nodes = new LinkedList<>(nodes.nodes);
+        super(nodes.size());
+        addAll(nodes);
     }
 
     ValidationPath() {
-        this.nodes = new LinkedList<>();
     }
 
-    @Override
-    public Iterator<Node> iterator() {
-        return nodes.iterator();
+    Node removeLast() {
+        return remove(size() - 1);
+    }
+
+    Node peekLast() {
+        return isEmpty() ? null : get(size() - 1);
     }
 
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        final Iterator<Node> i = nodes.iterator();
+        final Iterator<Node> i = iterator();
         boolean dontAddDot = true;
         while (i.hasNext()) {
             final Node node = i.next();
@@ -145,7 +147,7 @@ final class ValidationPath implements Path {
     }
 
     private ContextualPath addNode(Node node) {
-        nodes.add(node);
+        add(node);
         ContextualPath contextualPath = withContainerContext(DefaultContainerContext.NONE);
 
         return () -> {
@@ -182,18 +184,18 @@ final class ValidationPath implements Path {
                 return simpleName;
             }
         });
-        nodes.add(node);
+        add(node);
         return popPath;
     }
 
     public ContextualPath cascaded() {
-        Node last = nodes.peekLast();
+        Node last = peekLast();
         if (containerContext.containerClass() == null && last != null && last.getKind() == ElementKind.CONTAINER_ELEMENT) {
-            DefaultContainerElementNode removed = (DefaultContainerElementNode) nodes.removeLast();
+            DefaultContainerElementNode removed = (DefaultContainerElementNode) removeLast();
             ContainerContext prevContainerContext = containerContext;
             containerContext = removed.containerContext;
             return () -> {
-                nodes.add(removed);
+                add(removed);
                 containerContext = prevContainerContext;
             };
         }
@@ -202,20 +204,20 @@ final class ValidationPath implements Path {
     }
 
     public Node last() {
-        return nodes.peekLast();
+        return peekLast();
     }
 
     public ValidationPath previousPath() {
         ValidationPath path = new ValidationPath(this);
-        path.nodes.removeLast();
-        if (path.nodes.isEmpty()) {
-            path.nodes.add(new DefaultBeanNode(containerContext));
+        path.removeLast();
+        if (path.isEmpty()) {
+            path.add(new DefaultBeanNode(containerContext));
         }
         return path;
     }
 
     public ConstraintTarget getConstraintTarget() {
-        DefaultNode node = (DefaultNode) nodes.peekLast();
+        DefaultNode node = (DefaultNode) peekLast();
         return node == null ? ConstraintTarget.IMPLICIT : node.getConstraintTarget();
     }
 

--- a/validation/src/main/java/io/micronaut/validation/validator/constraints/DefaultConstraintValidators.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/constraints/DefaultConstraintValidators.java
@@ -25,7 +25,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
+import io.micronaut.core.util.CopyOnWriteMap;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.inject.qualifiers.TypeArgumentQualifier;
 import jakarta.inject.Inject;
@@ -55,8 +55,7 @@ import java.util.Optional;
 @Introspected
 public class DefaultConstraintValidators implements ConstraintValidatorRegistry {
 
-    private final Map<DefaultConstraintValidators.ValidatorKey, ConstraintValidator<?, ?>> validatorCache = new ConcurrentLinkedHashMap.
-            Builder<DefaultConstraintValidators.ValidatorKey, ConstraintValidator<?, ?>>().initialCapacity(10).maximumWeightedCapacity(40).build();
+    private final Map<DefaultConstraintValidators.ValidatorKey, ConstraintValidator<?, ?>> validatorCache = new CopyOnWriteMap<>(16 * 1024);
 
     @Nullable
     private final BeanContext beanContext;
@@ -118,6 +117,7 @@ public class DefaultConstraintValidators implements ConstraintValidatorRegistry 
                 new EmailValidator()
         );
         this.internalValidators = validatorMap;
+        this.validatorCache.putAll(validatorMap);
     }
 
     @SuppressWarnings("unchecked")
@@ -129,12 +129,12 @@ public class DefaultConstraintValidators implements ConstraintValidatorRegistry 
         final var key = new ValidatorKey(constraintType, targetType);
         targetType = (Class<T>) ReflectionUtils.getWrapperType(targetType);
 
-        ConstraintValidator<?, ?> constraintValidator = internalValidators.get(key);
+        ConstraintValidator<?, ?> constraintValidator = validatorCache.get(key);
         if (constraintValidator != null) {
             return Optional.of((ConstraintValidator<A, T>) constraintValidator);
         }
 
-        constraintValidator = validatorCache.get(key);
+        constraintValidator = internalValidators.get(key);
         if (constraintValidator != null) {
             return Optional.of((ConstraintValidator<A, T>) constraintValidator);
         }

--- a/validation/src/test/groovy/io/micronaut/validation/validator/constraints/disable/DisableDefaultConstraintViolationSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/constraints/disable/DisableDefaultConstraintViolationSpec.groovy
@@ -15,7 +15,7 @@ class DisableDefaultConstraintViolationSpec extends Specification {
         when:
             def results = validator.validate(new ValueObject(null, null, null));
             def violations = results.stream()
-                    .map(x -> "" + x.getPropertyPath() + ": " + x.getMessage())
+                    .map(x -> "" + x.getPropertyPath().toString() + ": " + x.getMessage())
                     .toList()
         then:
             violations == ["car: must not be null",


### PR DESCRIPTION
Various optimizations for a simple validation benchmark. I've not yet analyzed more complex validation use cases.

Each commit on this branch has one optimization, so it may be easier to review the commits individually.

before:

```
Benchmark                  Mode  Cnt     Score    Error  Units
ParameterBenchmark.string  avgt   10  2360.443 ± 68.948  ns/op
```

after:

```
Benchmark                  Mode  Cnt    Score    Error  Units
ParameterBenchmark.string  avgt   10  633.843 ± 12.849  ns/op
```

https://github.com/micronaut-projects/micronaut-core/pull/11970 can get this down further to around 400ns.