### PR TITLE
refactor: use JSpecify nullability annotations in Groovy test

### DIFF
--- a/validation/src/test/groovy/io/micronaut/validation/validator/customwithdefaultconstraints/EmployeeValidationsSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/customwithdefaultconstraints/EmployeeValidationsSpec.groovy
@@ -3,7 +3,7 @@ package io.micronaut.validation.validator.customwithdefaultconstraints
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Executable
 import io.micronaut.core.annotation.Introspected
-import io.micronaut.core.annotation.Nullable
+import org.jspecify.annotations.Nullable
 import io.micronaut.validation.validator.Validator
 import jakarta.inject.Singleton
 import spock.lang.AutoCleanup

--- a/validation/src/test/groovy/io/micronaut/validation/validator/customwithdefaultconstraints/EmployeeValidationsSpec.groovy
+++ b/validation/src/test/groovy/io/micronaut/validation/validator/customwithdefaultconstraints/EmployeeValidationsSpec.groovy
@@ -135,14 +135,13 @@ class Employee {
 
     private int experience
 
-    private Employee alternateRepresentative
+    private @Nullable Employee alternateRepresentative
 
     @Valid
     @NotNull
     private Designation designation
 
     @EmployeeExperienceConstraint
-    @Nullable
     Employee getAlternateRepresentative() {
         return alternateRepresentative
     }


### PR DESCRIPTION
This pull request replaces Micronaut's nullability annotations (io.micronaut.core.annotation.Nullable and
  io.micronaut.core.annotation.NonNull) with JSpecify's (org.jspecify.annotations.Nullable and org.jspecify.annotations.NonNull)
  within the validation module.

Fixes #587