### PR TITLE
Implement OverridesAttribute via core AliasFor remapping

### DIFF
--- a/tests/jakarta-validation-tck/build.gradle
+++ b/tests/jakarta-validation-tck/build.gradle
@@ -62,6 +62,8 @@ test {
 
 tasks.register('singleTest', Test) {
     scanForTestClasses false
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
     useTestNG {
         suiteXmlBuilder().suite(name: 'Sample Suite') {
             test(name : 'Sample Test') {

--- a/tests/jakarta-validation-tck/tck-tests.xml
+++ b/tests/jakarta-validation-tck/tck-tests.xml
@@ -143,10 +143,17 @@
                     <exclude name=".*"/>
                 </methods>
             </class>
-            <!-- TODO -->
+            <!-- TODO: groups/payload/validationAppliesTo propagation to composing constraints and @ReportAsSingleViolation -->
             <class name="org.hibernate.beanvalidation.tck.tests.constraints.constraintcomposition.ConstraintCompositionTest">
                 <methods>
-                    <exclude name=".*"/>
+                    <exclude name="testComposedConstraints"/>
+                    <exclude name="testComposedConstraintsAreRecursive"/>
+                    <exclude name="testConstraintTargetPropagationInComposedConstraints"/>
+                    <exclude name="testGroupsDefinedOnMainAnnotationAreInherited"/>
+                    <exclude name="testMixedConstraintTargetsInComposedAndComposingConstraintsCauseException"/>
+                    <exclude name="testMixedConstraintTargetsInComposingConstraintsCauseException"/>
+                    <exclude name="testOnlySingleConstraintViolation"/>
+                    <exclude name="testPayloadPropagationInComposedConstraints"/>
                 </methods>
             </class>
             <!-- TODO -->

--- a/validation-processor/src/main/java/io/micronaut/validation/transformer/OverridesAttributeAnnotationTransformer.java
+++ b/validation-processor/src/main/java/io/micronaut/validation/transformer/OverridesAttributeAnnotationTransformer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.validation.transformer;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.inject.annotation.TypedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+import jakarta.validation.OverridesAttribute;
+
+import java.util.List;
+
+/**
+ * Transforms {@link OverridesAttribute} on a member of a composed constraint into core's
+ * {@link AliasFor}, so the overridden values of the composing constraints are computed at
+ * build time as part of the annotation metadata.
+ *
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+public final class OverridesAttributeAnnotationTransformer implements TypedAnnotationTransformer<OverridesAttribute> {
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<OverridesAttribute> annotation, VisitorContext visitorContext) {
+        return List.of(toAliasFor(annotation));
+    }
+
+    @Override
+    public Class<OverridesAttribute> annotationType() {
+        return OverridesAttribute.class;
+    }
+
+    static AnnotationValue<AliasFor> toAliasFor(AnnotationValue<OverridesAttribute> annotation) {
+        AnnotationValueBuilder<AliasFor> builder = AnnotationValue.builder(AliasFor.class);
+        annotation.annotationClassValue("constraint").ifPresent(constraint -> builder.member("annotationName", constraint.getName()));
+        // An empty name means the annotated member's own name, which core fills in
+        annotation.stringValue("name").ifPresent(name -> builder.member("member", name));
+        annotation.intValue("constraintIndex").ifPresent(index -> builder.member("index", index));
+        // The overriding member value applies also when only its default is present
+        builder.member("applyDefault", true);
+        return builder.build();
+    }
+}

--- a/validation-processor/src/main/java/io/micronaut/validation/transformer/OverridesAttributeListAnnotationTransformer.java
+++ b/validation-processor/src/main/java/io/micronaut/validation/transformer/OverridesAttributeListAnnotationTransformer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.validation.transformer;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.TypedAnnotationTransformer;
+import io.micronaut.inject.visitor.VisitorContext;
+import jakarta.validation.OverridesAttribute;
+
+import java.util.List;
+
+/**
+ * Transforms the {@link OverridesAttribute.List} container into core {@code AliasFor} values,
+ * one per contained {@link OverridesAttribute}.
+ *
+ * @author Denis Stepanov
+ * @since 5.1
+ */
+public final class OverridesAttributeListAnnotationTransformer implements TypedAnnotationTransformer<OverridesAttribute.List> {
+
+    @Override
+    public List<AnnotationValue<?>> transform(AnnotationValue<OverridesAttribute.List> annotation, VisitorContext visitorContext) {
+        return annotation.<OverridesAttribute>getAnnotations(AnnotationMetadata.VALUE_MEMBER)
+            .stream()
+            .<AnnotationValue<?>>map(OverridesAttributeAnnotationTransformer::toAliasFor)
+            .toList();
+    }
+
+    @Override
+    public Class<OverridesAttribute.List> annotationType() {
+        return OverridesAttribute.List.class;
+    }
+}

--- a/validation-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
+++ b/validation-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationTransformer
@@ -1,0 +1,2 @@
+io.micronaut.validation.transformer.OverridesAttributeAnnotationTransformer
+io.micronaut.validation.transformer.OverridesAttributeListAnnotationTransformer

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultConstraintValidatorContext.java
@@ -148,6 +148,10 @@ public final class DefaultConstraintValidatorContext<R> implements ConstraintVal
     }
 
     public boolean containsGroup(Collection<Class<?>> constraintGroups) {
+        if (constraintGroups.isEmpty()) {
+            // Composing constraints of a composed constraint carry no explicit groups and apply to the default group
+            return currentGroups.contains(Default.class);
+        }
         if (currentGroups.contains(Default.class) && rootClass != null && constraintGroups.contains(rootClass)) {
             return true;
         }

--- a/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
+++ b/validation/src/main/java/io/micronaut/validation/validator/DefaultValidator.java
@@ -61,6 +61,8 @@ import jakarta.inject.Singleton;
 import jakarta.validation.ClockProvider;
 import jakarta.validation.Constraint;
 import jakarta.validation.ConstraintDeclarationException;
+import jakarta.validation.ConstraintDefinitionException;
+import jakarta.validation.OverridesAttribute;
 import jakarta.validation.ConstraintTarget;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -85,11 +87,14 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -133,6 +138,8 @@ public class DefaultValidator implements
     // than we should. We still set it comfortably high to avoid unnecessary evictions.
     private final ConcurrentMap<AnnotationMetadata, List<DefaultConstraintDescriptor<Annotation>>> constraintCache =
         new CopyOnWriteMap<>(65536);
+
+    private final Set<Class<? extends Annotation>> validatedConstraintTypes = ConcurrentHashMap.newKeySet();
 
     /**
      * Default constructor.
@@ -1468,6 +1475,10 @@ public class DefaultValidator implements
                 validator = constraintValidatorRegistry.findConstraintValidator(constraintType, elementArgument.getType()).orElse(null);
             }
             if (validator == null || validator == ConstraintValidator.VALID) {
+                if (hasComposingConstraints(constraintType)) {
+                    // A composed constraint without its own validator is validated through its composing constraints
+                    continue;
+                }
                 throw new UnexpectedTypeException("Cannot find a constraint validator for constraint: " + constraintType.getName() + " and type: " + elementArgument.getType());
             }
             try {
@@ -1518,6 +1529,110 @@ public class DefaultValidator implements
         return context.containsGroup(constraint.getGroups());
     }
 
+    private static boolean hasComposingConstraints(Class<? extends Annotation> constraintType) {
+        for (Annotation annotation : constraintType.getDeclaredAnnotations()) {
+            Class<? extends Annotation> annotationType = annotation.annotationType();
+            if (annotationType.isAnnotationPresent(Constraint.class)) {
+                return true;
+            }
+            if (repeatableConstraintComponentType(annotationType) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Nullable
+    private static Class<?> repeatableConstraintComponentType(Class<? extends Annotation> annotationType) {
+        try {
+            Class<?> componentType = annotationType.getDeclaredMethod("value").getReturnType().getComponentType();
+            if (componentType != null && componentType.isAnnotationPresent(Constraint.class)) {
+                return componentType;
+            }
+        } catch (NoSuchMethodException ignored) {
+            // Not a repeatable container
+        }
+        return null;
+    }
+
+    /**
+     * Validates the {@code OverridesAttribute} declarations of a composed constraint per the
+     * Jakarta Validation constraint composition rules.
+     */
+    private void validateConstraintDefinition(Class<? extends Annotation> constraintType) {
+        if (!validatedConstraintTypes.add(constraintType)) {
+            return;
+        }
+        // Collect the composing constraints, counting occurrences per constraint type and
+        // rejecting a mix of a direct annotation and its repeatable container
+        Map<Class<?>, Integer> occurrences = new LinkedHashMap<>();
+        Set<Class<?>> direct = new HashSet<>();
+        Set<Class<?>> viaContainer = new HashSet<>();
+        for (Annotation annotation : constraintType.getDeclaredAnnotations()) {
+            Class<? extends Annotation> annotationType = annotation.annotationType();
+            if (annotationType.isAnnotationPresent(Constraint.class)) {
+                occurrences.merge(annotationType, 1, Integer::sum);
+                direct.add(annotationType);
+            } else {
+                Class<?> componentType = repeatableConstraintComponentType(annotationType);
+                if (componentType != null) {
+                    try {
+                        Annotation[] values = (Annotation[]) annotationType.getDeclaredMethod("value").invoke(annotation);
+                        occurrences.merge(componentType, values.length, Integer::sum);
+                    } catch (ReflectiveOperationException e) {
+                        throw new ConstraintDeclarationException("Cannot read composing constraint container " + annotationType.getName(), e);
+                    }
+                    viaContainer.add(componentType);
+                }
+            }
+        }
+        for (Class<?> mixed : direct) {
+            if (viaContainer.contains(mixed)) {
+                throw new ConstraintDeclarationException("Constraint " + constraintType.getName()
+                    + " mixes a direct @" + mixed.getName() + " annotation and its repeatable container");
+            }
+        }
+        for (Method member : constraintType.getDeclaredMethods()) {
+            OverridesAttribute single = member.getAnnotation(OverridesAttribute.class);
+            if (single != null) {
+                validateOverride(constraintType, member, single, occurrences);
+            }
+            OverridesAttribute.List list = member.getAnnotation(OverridesAttribute.List.class);
+            if (list != null) {
+                for (OverridesAttribute override : list.value()) {
+                    validateOverride(constraintType, member, override, occurrences);
+                }
+            }
+        }
+    }
+
+    private static void validateOverride(Class<? extends Annotation> constraintType,
+                                         Method member,
+                                         OverridesAttribute override,
+                                         Map<Class<?>, Integer> occurrences) {
+        Class<? extends Annotation> target = override.constraint();
+        Integer count = occurrences.get(target);
+        if (count == null) {
+            throw new ConstraintDefinitionException("Constraint " + constraintType.getName() + " member '" + member.getName()
+                + "' overrides an attribute of " + target.getName() + " which is not a composing constraint");
+        }
+        if (override.constraintIndex() >= count) {
+            throw new ConstraintDefinitionException("Invalid constraintIndex " + override.constraintIndex() + " for constraint "
+                + target.getName() + " composing " + constraintType.getName());
+        }
+        String name = override.name().isEmpty() ? member.getName() : override.name();
+        Method overriddenMember;
+        try {
+            overriddenMember = target.getDeclaredMethod(name);
+        } catch (NoSuchMethodException e) {
+            throw new ConstraintDefinitionException("Overridden attribute '" + name + "' does not exist on constraint " + target.getName());
+        }
+        if (!overriddenMember.getReturnType().equals(member.getReturnType())) {
+            throw new ConstraintDefinitionException("The overriding member '" + member.getName() + "' of constraint "
+                + constraintType.getName() + " must match the type of the overridden attribute '" + name + "' of " + target.getName());
+        }
+    }
+
     private <R> List<DefaultConstraintDescriptor<Annotation>> getConstraints(DefaultConstraintValidatorContext<R> context,
                                                                              AnnotationMetadata annotationMetadata,
                                                                              boolean cache) {
@@ -1537,6 +1652,7 @@ public class DefaultValidator implements
                                                                               AnnotationMetadata annotationMetadata) {
         List<DefaultConstraintDescriptor<Annotation>> descriptors = new ArrayList<>();
         for (Class<? extends Annotation> constraintType : annotationMetadata.getAnnotationTypesByStereotype(Constraint.class)) {
+            validateConstraintDefinition(constraintType);
             List<? extends AnnotationValue<? extends Annotation>> annotationValuesByType = annotationMetadata.getAnnotationValuesByType(constraintType);
             if (annotationValuesByType.isEmpty()) {
                 annotationValuesByType = annotationMetadata.getDeclaredAnnotationValuesByType(constraintType);


### PR DESCRIPTION
## Summary

Implements `jakarta.validation.OverridesAttribute` by computing constraint-composition attribute overrides **at build time** in the annotation metadata, instead of runtime reflection:

- `validation-processor` registers `AnnotationTransformer`s that remap `@OverridesAttribute` (and its `List` container) to core's `@AliasFor`: `constraint` → `annotationName`, `name` → `member` (an empty name resolves to the member's own name in core), `constraintIndex` → `index`, plus `applyDefault = true` so the overriding member's default value applies.
- `DefaultValidator` runtime changes:
  - composing constraints (which carry no `groups` member) participate in the `Default` group instead of being silently filtered out
  - a composed constraint without its own validator is validated through its composing constraints instead of throwing `UnexpectedTypeException`
  - constraint definitions are validated per the composition rules, throwing `ConstraintDefinitionException` / `ConstraintDeclarationException` for overriding/overridden member type mismatches, out-of-range `constraintIndex`, overrides of non-composing constraints, and mixing a direct repeatable annotation with its container

## Requires

The matching micronaut-core support on branch [`claude/member-annotation-alias-remap`](https://github.com/micronaut-projects/micronaut-core/tree/claude/member-annotation-alias-remap): member-annotation transformer fallback in alias resolution, and the new `@AliasFor` members `applyDefault` and `index` with occurrence-aware stereotype reconciliation. Without that core, the transformers degrade to explicit-value-only aliasing.

## Verification

Run with the composite build against the core branch:

```
./gradlew --include-build ../micronaut-core :micronaut-tests:micronaut-jakarta-validation-tck:test
```

- All 8 OverridesAttribute-related `ConstraintCompositionTest` TCK methods now pass (from 0) and are un-excluded in `tck-tests.xml`: `testEachFailingConstraintCreatesConstraintViolation`, `testConstraintIndexWithListContainer`, `testConstraintIndexWithMixDirectAnnotationAndListContainer`, `testOverriddenAttributesMustMatchInType`, `testOverridesAttributeWithDefaultName`, `testAttributesDefinedOnComposingConstraints`, `testAllComposingConstraintsMustBeApplicableToAnnotatedType`, `testValidationOfMainAnnotationIsAlsoApplied`
- Full TCK suite (392 tests) green with them included
- Remaining `ConstraintCompositionTest` exclusions need groups/payload/`validationAppliesTo` propagation to composing constraints and `@ReportAsSingleViolation` — separate features, noted in the exclusion comment

## Notes for reviewers

- Overriding a member of a nested composed-of-composed constraint does not cascade into that constraint's own stereotype tree (core merges after stereotype processing); the TCK does not exercise this
- `ValidatorSpec` "@Introspected is required" tests fail against any 5.2.x core including pristine `origin/5.2.x` — a pre-existing branch/core mismatch unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)